### PR TITLE
ChatGPT APIをClaude 3.5 Sonnet APIに置き換え、メッセージ分割機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repository is a Discord bot built using Rust's Serenity. Hosting is provided by Shuttle.
 
 Since it is still under development, it has quite a few features, but the following functions are available:
-- When you make a mentions to the Bot, it gets the 5 latest messages and GPT will answer them.
+- When you make a mentions to the Bot, it gets the 5 latest messages and Claude 3.5 Sonnet will answer them.
+- Messages longer than 2000 characters are automatically split into multiple messages to comply with Discord's message length limit.
 - When a URL of x.com or twitter.com is pasted, it is converted to vxtwitter.com and posted
 
 ## Requirements
@@ -35,12 +36,12 @@ The required authority is **"MESSAGE CONTENT INTENT"**
 > The official Shuttle website describes [how to install the Hello world bot](https://docs.shuttle.rs/examples/serenity), but it also describes the operation of the Discord Developers Portal, so please refer to that if you are not sure.
 
 
-### Get a OpenAI token
+### Get an Anthropic Claude token
 
-To run this bot, you need a valid OpenAI token; login to the [OpenAI Profile | User APPI keys](https://platform.openai.com/settings/profile?tab=api-keys).
+To run this bot, you need a valid Anthropic Claude API token; login to the [Anthropic Console](https://console.anthropic.com/) and create an API key.
 
 > [!WARNING]
-> You must have charged credits to use OpenAI's ChatGPT API.
+> You must have a valid Anthropic account to use Claude API.
 
 ### Install Shuttle CLI
 
@@ -62,7 +63,7 @@ cargo shuttle login
 
 ```toml
 DISCORD_TOKEN="{{ token }}"
-CHATGPT_TOKEN="{{ token }}"
+CLAUDE_TOKEN="{{ token }}"
 ```
 
 > [!TIP]

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -1,0 +1,100 @@
+use reqwest;
+use reqwest::Error;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Debug)]
+struct ClaudeResponse {
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ContentBlock {
+    #[serde(rename = "type")]
+    content_type: String,
+    text: String,
+}
+
+#[derive(Serialize)]
+struct ClaudeRequest<'a> {
+    model: &'a str,
+    messages: Vec<RequestMessage<'a>>,
+    max_tokens: u32,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct RequestMessage<'a> {
+    pub role: &'a str,
+    pub content: String,
+}
+
+/// Claudeにリクエストを送信、レスポンスを取得
+pub async fn get_claude_response(
+    messages: Vec<RequestMessage<'_>>, // リクエストに含めるメッセージのベクター
+    claude_token: &str,                // Claude APIのアクセストークン
+    client: &reqwest::Client,          // reqwestのクライアントインスタンス
+) -> Result<String, Error> {
+    const URL: &str = "https://api.anthropic.com/v1/messages";
+    const CLAUDE_MODEL: &str = "claude-3-5-sonnet-20240620"; // Claudeのモデル名
+    const MAX_TOKENS: u32 = 4096; // 最大トークン数
+
+    let request_body = ClaudeRequest {
+        model: CLAUDE_MODEL,
+        messages,
+        max_tokens: MAX_TOKENS,
+    };
+
+    let response = client
+        .post(URL)
+        .header("Content-Type", "application/json")
+        .header("x-api-key", claude_token)
+        .header("anthropic-version", "2023-06-01")
+        .json(&request_body) // リクエストボディをJSONに変換
+        .send()
+        .await?
+        .json::<ClaudeResponse>() // レスポンスをClaudeResponse構造体にデシリアライズ
+        .await?;
+
+    // テキストコンテンツを結合
+    let content = response.content.iter()
+        .filter(|block| block.content_type == "text")
+        .map(|block| block.text.clone())
+        .collect::<Vec<String>>()
+        .join("");
+
+    log::info!("Response content length: {}", content.len());
+
+    return Ok(content);
+}
+
+/// Discordのメッセージ制限（2000文字）に合わせてメッセージを分割する
+pub fn split_message(message: &str, max_length: usize) -> Vec<String> {
+    if message.len() <= max_length {
+        return vec![message.to_string()];
+    }
+
+    let mut result = Vec::new();
+    let mut current_pos = 0;
+
+    while current_pos < message.len() {
+        let mut end_pos = std::cmp::min(current_pos + max_length, message.len());
+        
+        // 文字の途中で切らないように調整
+        if end_pos < message.len() {
+            // 最後の空白または改行を探す
+            while end_pos > current_pos && !message.is_char_boundary(end_pos) {
+                end_pos -= 1;
+            }
+            
+            // 文の途中で切らないように、最後の文章の区切りを探す
+            let substring = &message[current_pos..end_pos];
+            if let Some(last_period) = substring.rfind(|c| c == '。' || c == '.' || c == '!' || c == '?' || c == '\n') {
+                end_pos = current_pos + last_period + 1;
+            }
+        }
+
+        result.push(message[current_pos..end_pos].to_string());
+        current_pos = end_pos;
+    }
+
+    result
+}


### PR DESCRIPTION
## 変更内容

- ChatGPT APIをClaude 3.5 Sonnet APIに置き換え
- 2000文字を超えるDiscordメッセージを自動的に分割する機能を追加
- READMEを更新して変更点を反映

## 詳細

- ファイルを新規作成し、Claude APIとの通信機能を実装
- を修正してClaude APIを使用するように変更
- 長いメッセージを適切に分割して送信する機能を追加
- の設定を更新（→）
- READMEの説明を更新