### PR TITLE
Fix command registration by integrating Poise framework with main client

### DIFF
--- a/src/commands/age.rs
+++ b/src/commands/age.rs
@@ -1,7 +1,9 @@
 use chrono::{Datelike, Utc};
 use poise::serenity_prelude as serenity;
 
-pub struct Data {}
+// メインのData型を使用するため、ここでの定義は削除
+// 代わりにcrate::Dataを使用する
+use crate::Data;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, Data, Error>;


### PR DESCRIPTION
## 問題点

Discordボットのコマンドを実行すると「アプリケーションが応答しませんでした」というエラーが発生していました。

原因：
1. 関数が新しいSerenityクライアントを作成し、メインクライアントと競合
2. Rustの所有権とライフタイムの問題

## 修正内容

1. Poiseフレームワークをメインのクライアントに統合
2. 構造体を作成し、必要な情報を保持するように設定
3. コマンド登録を関数内で行い、アプリケーション起動時に自動的に登録されるように変更
4. Rustの所有権とライフタイムの問題を解決するために適切な変数のクローンとキーワードを追加

これにより、Discordボットは起動時にコマンドを正しく登録し、実行できるようになります。