### PR TITLE
feat: Discord Embedを全コマンド・イベントに実装

### DIFF
--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -1,5 +1,6 @@
 use crate::Data;
 use chrono::Utc;
+use poise::serenity_prelude::{CreateEmbed};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, Data, Error>;
@@ -15,7 +16,11 @@ pub async fn clear(ctx: Context<'_>) -> Result<(), Error> {
         reset_times.insert(channel_id, now);
     }
 
-    ctx.say("会話コンテキストをリセットしました。これ以降のメッセージのみAIへの入力として使用します。")
-        .await?;
+    let embed = CreateEmbed::new()
+        .title("🔄 会話リセット完了")
+        .description("会話コンテキストをリセットしました。\nこれ以降のメッセージのみ AI への入力として使用します。")
+        .color(0x57F287);
+
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
     Ok(())
 }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,4 +1,5 @@
 use crate::Data;
+use poise::serenity_prelude::{self as serenity, CreateEmbed};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, Data, Error>;
@@ -6,21 +7,33 @@ type Context<'a> = poise::Context<'a, Data, Error>;
 /// IdealX Botの使い方を表示するコマンド
 #[poise::command(slash_command, prefix_command)]
 pub async fn help(ctx: Context<'_>) -> Result<(), Error> {
-    let response = "**IdealX Bot コマンド一覧**\n\
-        \n\
-        **スラッシュコマンド**\n\
-        `/age [ユーザー]` — DiscordアカウントID作成日と経過日数を表示\n\
-        `/summarize [件数]` — 直近のメッセージをAIで要約（デフォルト10件、最大50件）\n\
-        `/translate [言語] [テキスト]` — テキストを指定言語に翻訳\n\
-        `/clear` — このチャンネルの会話コンテキストをリセット\n\
-        `/help` — このヘルプを表示\n\
-        \n\
-        **メンション**\n\
-        `@IdealX [メッセージ]` — AIに質問・相談（ウェブ検索対応）\n\
-        \n\
-        **リアクション**\n\
-        📝 リアクション → メッセージを要約してチャンネルに投稿";
+    let embed = CreateEmbed::new()
+        .title("🤖 IdealX Bot")
+        .description("Anthropic Claude AI を搭載した Discord ボットです。")
+        .color(0x5865F2)
+        .field(
+            "💬 メンション",
+            "`@IdealX [メッセージ]` — AIに質問・相談（ウェブ検索対応）",
+            false,
+        )
+        .field(
+            "📋 スラッシュコマンド",
+            "`/age [ユーザー]` — アカウント作成日と経過日数を表示\n\
+             `/summarize [件数]` — 直近のメッセージをAIで要約（最大50件）\n\
+             `/translate [言語] [テキスト]` — テキストを指定言語に翻訳\n\
+             `/clear` — このチャンネルの会話コンテキストをリセット\n\
+             `/help` — このヘルプを表示",
+            false,
+        )
+        .field(
+            "⚡ リアクション",
+            "📝 リアクション → メッセージを要約してチャンネルに投稿",
+            false,
+        )
+        .footer(serenity::CreateEmbedFooter::new(
+            "Powered by Claude claude-sonnet-4-6",
+        ));
 
-    ctx.say(response).await?;
+    ctx.send(poise::CreateReply::default().embed(embed)).await?;
     Ok(())
 }

--- a/src/commands/summarize.rs
+++ b/src/commands/summarize.rs
@@ -1,5 +1,5 @@
 use crate::{claude::RequestMessage, Data};
-use poise::serenity_prelude as serenity;
+use poise::serenity_prelude::{self as serenity, CreateEmbed};
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, Data, Error>;
@@ -26,7 +26,11 @@ pub async fn summarize(
         .join("\n");
 
     if formatted.is_empty() {
-        ctx.say("要約するメッセージがありません。").await?;
+        let embed = CreateEmbed::new()
+            .title("📝 要約")
+            .description("要約するメッセージがありません。")
+            .color(0xFEE75C);
+        ctx.send(poise::CreateReply::default().embed(embed)).await?;
         return Ok(());
     }
 
@@ -45,15 +49,23 @@ pub async fn summarize(
     .await
     {
         Ok(response) => {
-            ctx.say(format!(
-                "**直近{}件のメッセージの要約:**\n{}",
-                count, response
-            ))
-            .await?;
+            let embed = CreateEmbed::new()
+                .title("📝 会話の要約")
+                .description(&response)
+                .color(0x57F287)
+                .footer(serenity::CreateEmbedFooter::new(format!(
+                    "直近 {} 件のメッセージより",
+                    count
+                )))
+                .timestamp(serenity::Timestamp::now());
+            ctx.send(poise::CreateReply::default().embed(embed)).await?;
         }
         Err(e) => {
-            ctx.say(format!("要約中にエラーが発生しました: {}", e))
-                .await?;
+            let embed = CreateEmbed::new()
+                .title("❌ エラー")
+                .description(format!("要約中にエラーが発生しました: {}", e))
+                .color(0xED4245);
+            ctx.send(poise::CreateReply::default().embed(embed)).await?;
         }
     }
 


### PR DESCRIPTION
## Summary

- `/help`: フィールド分けでコマンド一覧を整形、フッターにモデル名（Claude claude-sonnet-4-6）を表示
- `/age`: ユーザーアバターをサムネイル表示、Discord ネイティブのタイムスタンプ形式 `<t:xxx:D>` で日付表示
- `/summarize`: 要約結果を緑色 Embed 化、フッターに件数・タイムスタンプ付き
- `/translate`: 原文と翻訳文を別フィールドに並べて紫色 Embed で表示
- `/clear`: リセット完了を緑色 Embed で通知
- **AI レスポンス（メンション・フォーラム）**: Blurple 色 Embed で返信（最大 4000 文字）、超過分はプレーンテキストで追送
- **📝 リアクション要約**: 黄色 Embed で要約、フッターに元メッセージの送信者名・タイムスタンプ付き
- **エラーメッセージ**: 全箇所で赤色 Embed に統一

## Test plan

- [x] `/help` でフィールド分けされた Embed が表示されること
- [x] `/age` でアバター・タイムスタンプ付き Embed が表示されること
- [x] `/summarize` で緑色の要約 Embed が表示されること
- [x] `/translate` で原文・翻訳文が別フィールドに表示されること
- [x] `/clear` でリセット完了 Embed が表示されること
- [x] Bot へのメンションで Blurple 色 Embed の返信が届くこと
- [x] 📝 リアクションで黄色の要約 Embed が投稿されること
- [x] エラー発生時に赤色 Embed が表示されること
- [x] `cargo build` が警告ゼロで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)